### PR TITLE
Add DeserializerAwareInterface

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,11 @@
 <?php
 
+$finder = PhpCsFixer\Finder::create()
+    ->path('src')->name('*.php')
+    ->path('tests')->name('*.php')
+    ->in(__DIR__)
+;
+
 return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
@@ -52,4 +58,5 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_alias_tag' => true,
     ])
+    ->setFinder($finder)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,9 +1,5 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-;
-
 return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
@@ -56,5 +52,4 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_alias_tag' => true,
     ])
-    ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 script:
   - mkdir -p build/logs
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-  - if [[ $TRAVIS_PHP_VERSION < 7.4 ]] ; then composer run-script fix-cs; fi;
+  - if [[ $TRAVIS_PHP_VERSION < 7.4 ]] ; then composer run-script lint; fi;
 
 after_script:
   - if [[ $TRAVIS_PHP_VERSION = 7.3] && [$PREFER_LOWEST  = "" ]] ; then php vendor/bin/php-coveralls -v; fi;

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,11 @@
         }
     },
     "scripts": {
-        "fix-cs": [
-            "vendor/bin/php-cs-fixer fix src",
-            "vendor/bin/php-cs-fixer fix tests"
+        "cs": "php-cs-fixer fix --allow-risky=yes",
+        "lint": "@cs --dry-run",
+        "test": [
+          "phpunit",
+          "@lint"
         ]
     },
     "require": {

--- a/src/DeserializerAwareInterface.php
+++ b/src/DeserializerAwareInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+* This file is part of the ObjectMapper library.
+*
+* (c) Martin Rademacher <mano@radebatz.net>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Radebatz\ObjectMapper;
+
+/**
+ * Interface to handle deserialization.
+ *
+ * This interface allows for more fine grained control
+ * over the de-serialization process.
+ */
+interface DeserializerAwareInterface
+{
+    /**
+     * Called directly after this instance has been created.
+     *
+     * @param ObjectMapper $objectMapper
+     */
+    public function instantiated(ObjectMapper $objectMapper): void;
+
+    /**
+     * Called after the instance has been fully deserialized and before it is assigned.
+     *
+     * @param ObjectMapper $objectMapper
+     */
+    public function deserialized(ObjectMapper $objectMapper): void;
+}

--- a/src/ObjectMapper.php
+++ b/src/ObjectMapper.php
@@ -279,8 +279,7 @@ class ObjectMapper
                         }
                     }
 
-                // fall through
-                // no break
+                    return new ObjectTypeMapper($this);
 
                 default:
                     return new ObjectTypeMapper($this);

--- a/src/TypeMapper/CollectionTypeMapper.php
+++ b/src/TypeMapper/CollectionTypeMapper.php
@@ -13,6 +13,7 @@ namespace Radebatz\ObjectMapper\TypeMapper;
 
 use Radebatz\ObjectMapper\ObjectMapper;
 use Radebatz\ObjectMapper\ObjectMapperException;
+use Radebatz\ObjectMapper\DeserializerAwareInterface;
 use Radebatz\ObjectMapper\TypeReference\ClassTypeReference;
 use Radebatz\ObjectMapper\TypeReference\CollectionTypeReference;
 use Radebatz\ObjectMapper\TypeReference\ObjectTypeReference;
@@ -46,6 +47,10 @@ class CollectionTypeMapper extends AbstractTypeMapper
         } elseif ($typeReference instanceof CollectionTypeReference) {
             if ($collectionType = $typeReference->getCollectionType()) {
                 $obj = new $collectionType();
+
+                if ($obj instanceof DeserializerAwareInterface) {
+                    $obj->instantiated($this->getObjectMapper());
+                }
             } else {
                 $obj = [];
             }
@@ -69,6 +74,10 @@ class CollectionTypeMapper extends AbstractTypeMapper
             } else {
                 $propertyAccessor->setValue($obj, $key, $val);
             }
+        }
+
+        if ($obj instanceof DeserializerAwareInterface) {
+            $obj->deserialized($this->getObjectMapper());
         }
 
         return $obj;

--- a/src/TypeMapper/ObjectTypeMapper.php
+++ b/src/TypeMapper/ObjectTypeMapper.php
@@ -14,6 +14,7 @@ namespace Radebatz\ObjectMapper\TypeMapper;
 use Radebatz\ObjectMapper\NamingMapperInterface;
 use Radebatz\ObjectMapper\ObjectMapper;
 use Radebatz\ObjectMapper\ObjectMapperException;
+use Radebatz\ObjectMapper\DeserializerAwareInterface;
 use Radebatz\ObjectMapper\TypeReference\ClassTypeReference;
 use Radebatz\ObjectMapper\TypeReference\ObjectTypeReference;
 use Radebatz\ObjectMapper\TypeReference\TypeReferenceFactory;
@@ -66,6 +67,10 @@ class ObjectTypeMapper extends AbstractTypeMapper
             }
 
             if ($ctorArg) {
+                if ($obj instanceof DeserializerAwareInterface) {
+                    $obj->deserialized($this->getObjectMapper());
+                }
+
                 return $obj;
             }
         }
@@ -110,6 +115,10 @@ class ObjectTypeMapper extends AbstractTypeMapper
 
         if ($this->getObjectMapper()->isOption(ObjectMapper::OPTION_VERIFY_REQUIRED)) {
             $this->verifyRequiredProperties(get_class($obj), $properties, $mappedProperties);
+        }
+
+        if ($obj instanceof DeserializerAwareInterface) {
+            $obj->deserialized($this->getObjectMapper());
         }
 
         return $obj;

--- a/tests/DeserializerAwareTest.php
+++ b/tests/DeserializerAwareTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+* This file is part of the ObjectMapper library.
+*
+* (c) Martin Rademacher <mano@radebatz.net>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Radebatz\ObjectMapper\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Radebatz\ObjectMapper\Tests\Models\DeserializerAwareCollection;
+use Radebatz\ObjectMapper\TypeReference\CollectionTypeReference;
+
+class DeserializerAwareTest extends TestCase
+{
+    use TestUtils;
+
+    public function testPopo()
+    {
+        $objectMapper = $this->getObjectMapper();
+
+        $json = '{"proString":"foo"}';
+        /** @var Models\DeserializerAwarePopo $popo */
+        $popo = $objectMapper->map($json, Models\DeserializerAwarePopo::class);
+        $this->assertInstanceOf(Models\DeserializerAwarePopo::class, $popo);
+        $this->assertEquals('i:nulld:foo', $popo->getAware());
+    }
+
+    public function testCollection()
+    {
+        $objectMapper = $this->getObjectMapper();
+
+        $json = '{"ping":"pong"}';
+        /** @var Models\DeserializerAwareCollection $popo */
+        $popo = $objectMapper->map($json, new CollectionTypeReference(\stdClass::class, DeserializerAwareCollection::class));
+        $this->assertInstanceOf(Models\DeserializerAwareCollection::class, $popo);
+        $this->assertEquals('i:0d:1', $popo->getAware());
+    }
+}

--- a/tests/Models/DeserializerAwareCollection.php
+++ b/tests/Models/DeserializerAwareCollection.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+* This file is part of the ObjectMapper library.
+*
+* (c) Martin Rademacher <mano@radebatz.net>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Radebatz\ObjectMapper\Tests\Models;
+
+use Radebatz\ObjectMapper\DeserializerAwareInterface;
+use Radebatz\ObjectMapper\ObjectMapper;
+
+class DeserializerAwareCollection extends \ArrayObject implements DeserializerAwareInterface
+{
+    protected $aware = '';
+
+    /**
+     * @return string
+     */
+    public function getAware(): string
+    {
+        return $this->aware;
+    }
+
+    /** {@inheritdoc} */
+    public function instantiated(ObjectMapper $objectMapper): void
+    {
+        $this->aware .= 'i:' . $this->count();
+    }
+
+    /** {@inheritdoc} */
+    public function deserialized(ObjectMapper $objectMapper): void
+    {
+        $this->aware .= 'd:' . $this->count();
+    }
+}

--- a/tests/Models/DeserializerAwarePopo.php
+++ b/tests/Models/DeserializerAwarePopo.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+* This file is part of the ObjectMapper library.
+*
+* (c) Martin Rademacher <mano@radebatz.net>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Radebatz\ObjectMapper\Tests\Models;
+
+use Radebatz\ObjectMapper\DeserializerAwareInterface;
+use Radebatz\ObjectMapper\ObjectMapper;
+
+class DeserializerAwarePopo implements DeserializerAwareInterface
+{
+    protected $proString = 'null';
+    protected $aware = '';
+
+    public function getProString(): ?string
+    {
+        return $this->proString;
+    }
+
+    public function setProString(?string $proString): void
+    {
+        $this->proString = $proString;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAware(): string
+    {
+        return $this->aware;
+    }
+
+    /** {@inheritdoc} */
+    public function instantiated(ObjectMapper $objectMapper): void
+    {
+        $this->aware .= 'i:' . $this->proString;
+    }
+
+    /** {@inheritdoc} */
+    public function deserialized(ObjectMapper $objectMapper): void
+    {
+        $this->aware .= 'd:' . $this->proString;
+    }
+}


### PR DESCRIPTION
The `DeserializerAwareInterface` allows model classes more fine grained control over the deserialization process.
`instantiated(ObjectMapper $objectMapper)` is called right after a model object is instantiated.
`deserialized(ObjectMapper $objectMapper)` is called once the default deserialization process is finished.